### PR TITLE
dynamicEDT3D converted to template form, for now only OctomapStamped …

### DIFF
--- a/dynamicEDT3D/include/dynamicEDT3D/dynamicEDTOctomap.h
+++ b/dynamicEDT3D/include/dynamicEDT3D/dynamicEDTOctomap.h
@@ -40,8 +40,10 @@
 
 #include "dynamicEDT3D.h"
 #include <octomap/OcTree.h>
+#include <octomap/OcTreeStamped.h>
 
 /// A DynamicEDTOctomap object connects a DynamicEDT3D object to an octomap.
+template <class TREE = octomap::OcTree>
 class DynamicEDTOctomap: private DynamicEDT3D {
 public:
     /** Create a DynamicEDTOctomap object that maintains a distance transform in the bounding box given by bbxMin, bbxMax and clamps distances at maxdist.
@@ -51,7 +53,7 @@ public:
      *
      *  The distance map is maintained in a full three-dimensional array, i.e., there exists a float field in memory for every voxel inside the bounding box given by bbxMin and bbxMax. Consider this when computing distance maps for large octomaps, they will use much more memory than the octomap itself!
      */
-	DynamicEDTOctomap(float maxdist, octomap::OcTree* _octree, octomap::point3d bbxMin, octomap::point3d bbxMax, bool treatUnknownAsOccupied);
+	DynamicEDTOctomap(float maxdist, TREE* _octree, octomap::point3d bbxMin, octomap::point3d bbxMax, bool treatUnknownAsOccupied);
 
 	virtual ~DynamicEDTOctomap();
 
@@ -111,7 +113,7 @@ private:
 	void mapToWorld(int x, int y, int z, octomap::point3d &p) const;
 	void mapToWorld(int x, int y, int z, octomap::OcTreeKey &key) const;
 
-	octomap::OcTree* octree;
+	TREE* octree;
 	bool unknownOccupied;
 	int treeDepth;
 	double treeResolution;
@@ -119,5 +121,7 @@ private:
 	octomap::OcTreeKey boundingBoxMaxKey;
 	int offsetX, offsetY, offsetZ;
 };
+
+#include "dynamicEDTOctomap.hxx"
 
 #endif /* DYNAMICEDTOCTOMAP_H_ */

--- a/dynamicEDT3D/include/dynamicEDT3D/dynamicEDTOctomap.h
+++ b/dynamicEDT3D/include/dynamicEDT3D/dynamicEDTOctomap.h
@@ -42,36 +42,36 @@
 #include <octomap/OcTree.h>
 #include <octomap/OcTreeStamped.h>
 
-/// A DynamicEDTOctomap object connects a DynamicEDT3D object to an octomap.
-template <class TREE = octomap::OcTree>
-class DynamicEDTOctomap: private DynamicEDT3D {
+/// A DynamicEDTOctomapBase object connects a DynamicEDT3D object to an octomap.
+template <class TREE, class NODE>
+class DynamicEDTOctomapBase: private DynamicEDT3D {
 public:
-    /** Create a DynamicEDTOctomap object that maintains a distance transform in the bounding box given by bbxMin, bbxMax and clamps distances at maxdist.
+    /** Create a DynamicEDTOctomapBase object that maintains a distance transform in the bounding box given by bbxMin, bbxMax and clamps distances at maxdist.
      *  treatUnknownAsOccupied configures the treatment of unknown cells in the distance computation.
      *
      *  The constructor copies occupancy data but does not yet compute the distance map. You need to call udpate to do this.
      *
      *  The distance map is maintained in a full three-dimensional array, i.e., there exists a float field in memory for every voxel inside the bounding box given by bbxMin and bbxMax. Consider this when computing distance maps for large octomaps, they will use much more memory than the octomap itself!
      */
-	DynamicEDTOctomap(float maxdist, TREE* _octree, octomap::point3d bbxMin, octomap::point3d bbxMax, bool treatUnknownAsOccupied);
+	DynamicEDTOctomapBase(float maxdist, TREE* _octree, octomap::point3d bbxMin, octomap::point3d bbxMax, bool treatUnknownAsOccupied);
 
-	virtual ~DynamicEDTOctomap();
+	virtual ~DynamicEDTOctomapBase();
 
 	///trigger updating of the distance map. This will query the octomap for the set of changes since the last update.
 	///If you set updateRealDist to false, computations will be faster (square root will be omitted), but you can only retrieve squared distances
 	virtual void update(bool updateRealDist=true);
 
 	///retrieves distance and closestObstacle (closestObstacle is to be discarded if distance is maximum distance, the method does not write closestObstacle in this case).
-	///Returns DynamicEDTOctomap::distanceValue_Error if point is outside the map.
+	///Returns DynamicEDTOctomapBase::distanceValue_Error if point is outside the map.
 	void getDistanceAndClosestObstacle(const octomap::point3d& p, float &distance, octomap::point3d& closestObstacle) const;
 
-	///retrieves distance at point. Returns DynamicEDTOctomap::distanceValue_Error if point is outside the map.
+	///retrieves distance at point. Returns DynamicEDTOctomapBase::distanceValue_Error if point is outside the map.
 	float getDistance(const octomap::point3d& p) const;
 
-	///retrieves distance at key. Returns DynamicEDTOctomap::distanceValue_Error if key is outside the map.
+	///retrieves distance at key. Returns DynamicEDTOctomapBase::distanceValue_Error if key is outside the map.
 	float getDistance(const octomap::OcTreeKey& k) const;
 
-	///retrieves squared distance in cells at point. Returns DynamicEDTOctomap::distanceInCellsValue_Error if point is outside the map.
+	///retrieves squared distance in cells at point. Returns DynamicEDTOctomapBase::distanceInCellsValue_Error if point is outside the map.
 	int getSquaredDistanceInCells(const octomap::point3d& p) const;
 
 	//variant of getDistanceAndClosestObstacle that ommits the check whether p is inside the area of the distance map. Use only if you are certain that p is covered by the distance map and if you need to save the time of the check.
@@ -121,6 +121,9 @@ private:
 	octomap::OcTreeKey boundingBoxMaxKey;
 	int offsetX, offsetY, offsetZ;
 };
+
+typedef DynamicEDTOctomapBase<octomap::OcTree, octomap::OcTreeNode> DynamicEDTOctomap;
+typedef DynamicEDTOctomapBase<octomap::OcTreeStamped, octomap::OcTreeNodeStamped> DynamicEDTOctomapStamped;
 
 #include "dynamicEDTOctomap.hxx"
 

--- a/dynamicEDT3D/src/CMakeLists.txt
+++ b/dynamicEDT3D/src/CMakeLists.txt
@@ -1,6 +1,5 @@
 SET( dynamicEDT3D_SRCS
    dynamicEDT3D.cpp
-   dynamicEDTOctomap.cpp
    )
 
 add_library(dynamicedt3d SHARED ${dynamicEDT3D_SRCS})

--- a/dynamicEDT3D/src/examples/CMakeLists.txt
+++ b/dynamicEDT3D/src/examples/CMakeLists.txt
@@ -3,3 +3,6 @@ target_link_libraries(exampleEDT3D dynamicedt3d)
 
 add_executable(exampleEDTOctomap exampleEDTOctomap.cpp)
 target_link_libraries(exampleEDTOctomap dynamicedt3d)
+
+add_executable(exampleEDTOctomapStamped exampleEDTOctomapStamped.cpp)
+target_link_libraries(exampleEDTOctomapStamped dynamicedt3d)

--- a/dynamicEDT3D/src/examples/exampleEDTOctomap.cpp
+++ b/dynamicEDT3D/src/examples/exampleEDTOctomap.cpp
@@ -35,9 +35,11 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
+#include <dynamicEDT3D/dynamicEDTOctomap.h>
+
 #include <iostream>
 
-#include <dynamicEDT3D/dynamicEDTOctomap.h>
+
 
 int main( int argc, char *argv[] ) {
   if(argc<=1){
@@ -45,9 +47,8 @@ int main( int argc, char *argv[] ) {
     exit(0);
   }
 
-  typedef octomap::OcTree OcTreeType;
-  OcTreeType *tree = NULL;
-  tree = new OcTreeType(0.05);
+  octomap::OcTree *tree = NULL;
+  tree = new octomap::OcTree(0.05);
 
   //read in octotree
   tree->readBinary(argv[1]);
@@ -65,12 +66,12 @@ int main( int argc, char *argv[] ) {
   bool unknownAsOccupied = true;
   unknownAsOccupied = false;
   float maxDist = 1.0;
-  //- the first argument is the max distance at which distance computations are clamped
+  //- the first argument ist the max distance at which distance computations are clamped
   //- the second argument is the octomap
   //- arguments 3 and 4 can be used to restrict the distance map to a subarea
   //- argument 5 defines whether unknown space is treated as occupied or free
   //The constructor copies data but does not yet compute the distance map
-  DynamicEDTOctomap<OcTreeType> distmap(maxDist, tree, min, max, unknownAsOccupied);
+  DynamicEDTOctomap distmap(maxDist, tree, min, max, unknownAsOccupied);
 
   //This computes the distance map
   distmap.update(); 

--- a/dynamicEDT3D/src/examples/exampleEDTOctomapStamped.cpp
+++ b/dynamicEDT3D/src/examples/exampleEDTOctomapStamped.cpp
@@ -35,9 +35,11 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
+#include <dynamicEDT3D/dynamicEDTOctomap.h>
+
 #include <iostream>
 
-#include <dynamicEDT3D/dynamicEDTOctomap.h>
+
 
 int main( int argc, char *argv[] ) {
   if(argc<=1){
@@ -45,7 +47,7 @@ int main( int argc, char *argv[] ) {
     exit(0);
   }
 
-  typedef octomap::OcTree OcTreeType;
+  typedef octomap::OcTreeStamped OcTreeType;
   OcTreeType *tree = NULL;
   tree = new OcTreeType(0.05);
 

--- a/dynamicEDT3D/src/examples/exampleEDTOctomapStamped.cpp
+++ b/dynamicEDT3D/src/examples/exampleEDTOctomapStamped.cpp
@@ -72,7 +72,7 @@ int main( int argc, char *argv[] ) {
   //- arguments 3 and 4 can be used to restrict the distance map to a subarea
   //- argument 5 defines whether unknown space is treated as occupied or free
   //The constructor copies data but does not yet compute the distance map
-  DynamicEDTOctomap<OcTreeType> distmap(maxDist, tree, min, max, unknownAsOccupied);
+  DynamicEDTOctomapStamped distmap(maxDist, tree, min, max, unknownAsOccupied);
 
   //This computes the distance map
   distmap.update(); 


### PR DESCRIPTION
A templated version of dynamicEDT3D class has been created. The templated type 'OcTreeType' should derive from 'OccupancyOcTreeBase' and the node type should be compatible with static casting to 'OcTreeNode'. The templates that have been tested are OcTree and OcTreeStamped.